### PR TITLE
Fix grid. Show times correctly in grid

### DIFF
--- a/web/helpers/refresh_helper.rb
+++ b/web/helpers/refresh_helper.rb
@@ -21,7 +21,14 @@ end
 
 # Includes milliseconds so receiver can differential fine-grained updates
 def format_date( date )
-  date.strftime( "%Y-%m-%dT%H:%M:%S:%L%z" ) if date
+	date.strftime( "%Y-%m-%dT%H:%M:%S:%L%z" ) if date
+end
+
+def format_date_utc( date )
+	if date
+		utc_date = date.new_offset(0)
+		utc_date.strftime( "%Y-%m-%dT%H:%M:%S.%LZ" )
+	end
 end
 
 # Add conversion from Time to Milliseconds

--- a/web/javascripts/views/indexBootstrap/Channel.js
+++ b/web/javascripts/views/indexBootstrap/Channel.js
@@ -9,7 +9,7 @@ function Channel(channel, players){
 	this.update(channel, players);
 	this.cb = {};
 	this.removed = false;
-	this.timestamp = new Date();
+	this.timestamp = new Date().toISOString();
 }
 
 
@@ -146,9 +146,9 @@ Channel.prototype.draw = function(players){
 				numPH++;
 			}
 			if(obj.find('.'+lemma_id.replace(/\s+/g, '-')).size() == 0){
-				obj.append($("<td></td>").hide().fadeIn(1000).addClass(lemma_id.replace(/\s+/g, '-')).html(hear + plays));
+				obj.append($("<td></td>").hide().fadeIn(1000).addClass(lemma_id.replace(/\s+/g, '-')).css("display", "table-cell").html(hear + plays));
 			} else {
-				obj.find('.'+lemma_id.replace(/\s+/g, '-')).html(hear + plays);
+				obj.find('.'+lemma_id.replace(/\s+/g, '-')).css("display", "table-cell").html(hear + plays);
 			}
 		}
 		if(numPH == 0){

--- a/web/noam_web.rb
+++ b/web/noam_web.rb
@@ -376,7 +376,7 @@ class NoamApp < Sinatra::Base
       players[spalla_id] = {
         :spalla_id => spalla_id,
         :device_type => player.device_type,
-        :last_activity => format_date( player.last_activity ),
+        :last_activity => format_date_utc( player.last_activity ),
         :system_version => player.system_version,
         :hears => player.hears,
         :plays => player.plays,
@@ -389,7 +389,7 @@ class NoamApp < Sinatra::Base
     @orchestra.event_names.dup.each do |event|
       events[event.to_s] = {
         :value_escaped => value_escaped(@values.get(event)),
-        :timestamp => format_date( @values.timestamp(event) )
+        :timestamp => format_date_utc( @values.timestamp(event) )
       }
     end
 


### PR DESCRIPTION
@evanShap @dougbradbury To review
2 things changed to make it work in Firefox
- timeago only works with utc times, so changed everywhere to have utc
- explicitly set the table-cell style (it was set by default in Chrome, but not in Firefox) 
