### PR TITLE
Swap 'warn' for 'debug' with close_connection error

### DIFF
--- a/lib/noam_server/ear.rb
+++ b/lib/noam_server/ear.rb
@@ -61,7 +61,7 @@ module NoamServer
       connection.close_connection_after_writing if connection
     rescue RuntimeError => e
       stack_trace = e.backtrace.join("\n  == ")
-      NoamLogging.warn(self, "Error: #{e.to_s}\n Stack Trace:\n == #{stack_trace}")
+      NoamLogging.debug(self, "Error: #{e.to_s}\n Stack Trace:\n == #{stack_trace}")
     end
 
   end


### PR DESCRIPTION
This change will avoid spamming unnecessary logging while performing Lemma Verification.
