### PR TITLE
Store orchestra last modified and use it for server beacon

### DIFF
--- a/lib/noam_server/noam_main.rb
+++ b/lib/noam_server/noam_main.rb
@@ -34,7 +34,7 @@ module NoamServer
       @webserver = WebSocketServer.new(ConfigManager[:web_socket_port])
       @broadcaster = UdpBroadcaster.new(ConfigManager[:broadcast_port],
                                         ConfigManager[:web_server_port],
-                                       GrabbedLemmas.instance)
+                                       Orchestra.instance)
       @marcopolo = UdpListener.new
       OtherGuestsList.instance(LocatedServers.instance)
     end

--- a/lib/noam_server/orchestra.rb
+++ b/lib/noam_server/orchestra.rb
@@ -7,7 +7,7 @@ require 'noam/sorting'
 
 module NoamServer
   class Orchestra
-    attr_reader :players, :events
+    attr_reader :players, :events, :last_modified
 
     def self.instance
       @instance ||= self.new
@@ -20,6 +20,7 @@ module NoamServer
       @play_callbacks = []
       @register_callbacks = []
       @unregister_callbacks = []
+			@last_modified = Time.now.utc
     end
 
     def clear
@@ -45,6 +46,8 @@ module NoamServer
 
       UnconnectedLemmas.instance.delete(spalla_id)
 
+			update_last_modified
+
       player.plays.each do |event|
         @events[event] ||= {}
       end
@@ -64,6 +67,8 @@ module NoamServer
         actors.delete(spalla_id)
         actors.empty?
       end
+
+			update_last_modified
 
 			@unregister_callbacks.each do |callback|
         callback.call(player)
@@ -151,6 +156,12 @@ module NoamServer
 		def get_players(order=nil)
 			return Noam::Sorting.run(players,order) if order
 			return players.dup
+		end
+
+		private
+
+		def update_last_modified
+			@last_modified = Time.now.utc
 		end
 
   end

--- a/lib/noam_server/udp_broadcaster.rb
+++ b/lib/noam_server/udp_broadcaster.rb
@@ -5,11 +5,11 @@ require 'noam_server/noam_logging'
 
 module NoamServer
   class UdpBroadcaster
-    def initialize(broadcast_port, http_port, lemmas)
+    def initialize(broadcast_port, http_port, orchestra)
       @http_port = http_port
       @broadcast_port = broadcast_port
       @socket = UDPSocket.new
-      @lemmas = lemmas
+      @orchestra = orchestra
       @socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_BROADCAST, true)
       broadcast_addresses.each do |address|
         log_broadcasting(address)
@@ -21,7 +21,7 @@ module NoamServer
     end
 
     def message_to_broadcast
-      Noam::Messages.build_server_beacon(NoamServer.room_name, @http_port, @lemmas.last_modified)
+			Noam::Messages.build_server_beacon(NoamServer.room_name, @http_port, @orchestra.last_modified)
     end
 
     def go

--- a/spec/noam_server/orchestra_spec.rb
+++ b/spec/noam_server/orchestra_spec.rb
@@ -60,7 +60,13 @@ describe NoamServer::Orchestra do
     orchestra.play("listens_for_1", 12.42, player_1.spalla_id )
   end
 
-  it "deletes newly-registered players from the unconnected list" do
+	it "changes last modified when a player is registered" do
+		before = orchestra.last_modified
+		orchestra.register(connection_1, player_1)
+		orchestra.last_modified.should_not == before
+	end
+
+	it "deletes newly-registered players from the unconnected list" do
     NoamServer::UnconnectedLemmas.instance.add({:name => id_1})
     NoamServer::UnconnectedLemmas.instance.get(id_1).should_not == nil
     orchestra.register(connection_1, player_1)
@@ -71,9 +77,17 @@ describe NoamServer::Orchestra do
     orchestra.register( connection_1, player_1 )
     orchestra.fire_player( id_1 )
     orchestra.players.has_key?( id_1 ).should be_false
-  end
+	end
 
-  it "updates events when a player is fired" do
+	it "changes last modified when a player is fired" do
+		orchestra.register( connection_1, player_1 )
+		before = orchestra.last_modified
+		orchestra.fire_player( id_1 )
+		orchestra.last_modified.should_not == before
+	end
+
+
+	it "updates events when a player is fired" do
     orchestra.register( connection_1, player_1 )
     player_3 = NoamServer::Player.new( "Web #3", 'Virtual Machine', 'System Version',
                                       ["listens_for_1", "listens_for_2"],


### PR DESCRIPTION
To review @dougbradbury @evanShap 
Uses last modified maintained in Orchestra.
Another use case that I tested is: similar to the one described in #25 but connecting the lemma directly to the room. Then, when I killed the lemma it disappears from the 2nd host (it was not disappearing before)
